### PR TITLE
Update: Restrict management & monitoring layer to specific IP range.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Variable Name | Type | Default Value |  Description
 --- | --- | --- | ---
 container_data_dir | String | `/data` | Default Data directory to store all container data with in.
 monitoring_docker_network | String | `monitoring` | The Docker network name for the monitoring containers.
+management_whitelist_ip_range | String | ❌ | The IP Range to lock access to for the monitoring and management layer. Example: `192.168.6.184/32`
 traefik_docker_network | String | `web` | The Docker network name for traefik to watch.
 traefik_ssl_email | String | ❌ | Email address for SSL LETSENCRYPT Certificate.
 traefik_htpasswd | String | ❌ | Admin username and password for Traefik access. Generate this in the command line with: `htpasswd -nb admin <secure password here>` copy and paste the whole line.

--- a/host_vars/wordpress-host.yml
+++ b/host_vars/wordpress-host.yml
@@ -17,6 +17,11 @@ container_data_dir: "/data"
 # Type: String
 monitoring_docker_network: "monitoring"
 
+# The IP Range to lock access to for the monitoring and management layer
+# Example open to the world:
+# management_whitelist_ip_range: "0.0.0.0/0"
+management_whitelist_ip_range: "0.0.0.0/0"
+
 # The Docker network name for traefik
 # If not specified it will be the default "web"
 # as below.

--- a/roles/wordpress-monitored/defaults/main.yml
+++ b/roles/wordpress-monitored/defaults/main.yml
@@ -17,6 +17,11 @@ container_data_dir: "/data"
 # Type: String
 monitoring_docker_network: "monitoring"
 
+# The IP Range to lock access to for the monitoring and management layer
+# Example open to the world:
+# management_whitelist_ip_range: "0.0.0.0/0"
+management_whitelist_ip_range: ""
+
 # The Docker network name for traefik
 # If not specified it will be the default "web"
 # as below.

--- a/roles/wordpress-monitored/tasks/grafana.yml
+++ b/roles/wordpress-monitored/tasks/grafana.yml
@@ -82,6 +82,7 @@
       traefik.frontend.rule: "Host:grafana.{{ traefik_domain }}"
       traefik.docker.network: "{{ traefik_docker_network }}"
       traefik.port: "3000"
+      traefik.frontend.whiteList.sourceRange: "{{ management_whitelist_ip_range }}"
     user: '0'
     env:
       GF_SECURITY_ADMIN_PASSWORD: "{{ grafana_admin_password }}"

--- a/roles/wordpress-monitored/tasks/portainer.yml
+++ b/roles/wordpress-monitored/tasks/portainer.yml
@@ -25,6 +25,7 @@
       traefik.frontend.rule: "Host:port.{{ traefik_domain }}"
       traefik.docker.network: "{{ traefik_docker_network }}"
       traefik.port: "9000"
+      traefik.frontend.whiteList.sourceRange: "{{ management_whitelist_ip_range }}"
     volumes:
       - /data/portainer:/data
       - /var/run/docker.sock:/var/run/docker.sock

--- a/roles/wordpress-monitored/tasks/prom.yml
+++ b/roles/wordpress-monitored/tasks/prom.yml
@@ -34,6 +34,7 @@
       traefik.frontend.rule: "Host:prom.{{ traefik_domain }}"
       traefik.docker.network: "{{ traefik_docker_network }}"
       traefik.port: "9090"
+      traefik.frontend.whiteList.sourceRange: "{{ management_whitelist_ip_range }}"
     command:
       - --config.file=/etc/prometheus/prometheus.yml
       - --storage.tsdb.path=/etc/prometheus/data

--- a/roles/wordpress-monitored/tasks/traefik.yml
+++ b/roles/wordpress-monitored/tasks/traefik.yml
@@ -52,6 +52,7 @@
     labels:
       traefik.frontend.rule: "Host:monitor.{{ traefik_domain }}"
       traefik.port: "8080"
+      traefik.frontend.whiteList.sourceRange: "{{ management_whitelist_ip_range }}"
     restart_policy: unless-stopped
   tags:
     - traefik


### PR DESCRIPTION
# What Was Done?

Added extra label to Monitoring and Management layer containers to restrict access by only IP Range:

- Traefik
- Grafana
- Prometheus
- Portainer

With this change, if someone accesses your dns endpoint from an IP outside of the provided IP ranges they will receive a page saying Forbidden.

# New Variables

Added variable for configuration and updated README.md to reflect changes.